### PR TITLE
change: sort addresses alphabetically

### DIFF
--- a/generate-address-list.py
+++ b/generate-address-list.py
@@ -98,6 +98,8 @@ def main():
 
         # deduplicate addresses
         addresses = list(dict.fromkeys(addresses).keys())
+        # sort addresses
+        addresses.sort()
 
         write_addresses(addresses, asset, output_formats, args.outpath)
 


### PR DESCRIPTION
In the past, changes to the entity order in the SDN list have caused changes to the automatically generated list by reordering the already sanctioned addresses. To avoid this, the exported addresses are now sorted.

See e.g. https://github.com/0xB10C/ofac-sanctioned-digital-currency-addresses/commit/80476d40f33d31f9d3cea9df7a483d0c2cf6a5d8