### PR TITLE
fix: don't re-generate list on PRs or pushes

### DIFF
--- a/.github/workflows/generate-lists.yml
+++ b/.github/workflows/generate-lists.yml
@@ -5,8 +5,6 @@ name: Generate OFAC sanctioned digital currency addresses lists each night at 0 
 on:
   schedule:
     - cron: '0 0 * * *'
-  push:
-  pull_request:
 
 jobs:
   generate-lists:


### PR DESCRIPTION
Previously, the workflow was trigger on PRs and pushes to any branch. We only want to update the lists every night.