### PR TITLE
change: instead of 0:00 UTC, run at 1:24 UTC

### DIFF
--- a/.github/workflows/generate-lists.yml
+++ b/.github/workflows/generate-lists.yml
@@ -4,7 +4,7 @@ name: Generate OFAC sanctioned digital currency addresses lists each night at 0 
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '24 1 * * *'
   workflow_dispatch:
 
 


### PR DESCRIPTION
From time to time, the cron based GitHub action runs at 0:00 UTC fail (https://github.com/0xB10C/ofac-sanctioned-digital-currency-addresses/actions) with a 403 error from the OFAC website.

```
--2024-11-06 00:34:47--  https://sanctionslistservice.ofac.treas.gov/api/PublicationPreview/exports/SDN_ADVANCED.ZIP
Resolving sanctionslistservice.ofac.treas.gov (sanctionslistservice.ofac.treas.gov)... 164.95.9.80, 2610:108:3100:100c::9:290
Connecting to sanctionslistservice.ofac.treas.gov (sanctionslistservice.ofac.treas.gov)|164.95.9.80|:443... connected.
HTTP request sent, awaiting response... 403 Forbidden
2024-11-06 00:34:48 ERROR 403: Forbidden.
```

There a multiple possibilites why this could be happening:
- Too many jobs try to access the file around 0:00 UTC and potential rate-limiting triggers
- The file is being updated at that time

Move the time to 1:24 UTC (randomly choosen) to possibly avoid this. I don't see how this could hurt.