### PR TITLE
Add DOGE, which is sanctioned but was not being extracted

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ an issue or pull-request adding assets.
 - ARB (Arbitrum)
 - BSC (Binance Smart Chain)
 - SOL (Solana)
+- DOGE (Dogecoin)
 
 The sanctioned addresses can be extracted with this tool from the
 [`sdn_advanced.xml`][2] file. The tool supports the following output formats:

--- a/generate-address-list.py
+++ b/generate-address-list.py
@@ -12,7 +12,7 @@ NAMESPACE = {'sdn': 'https://sanctionslistservice.ofac.treas.gov/api/Publication
 # Possible assets be seen by grepping the sdn_advanced.xml file for "Digital Currency Address".
 POSSIBLE_ASSETS = ["XBT", "ETH", "XMR", "LTC", "ZEC", "DASH", "BTG", "ETC",
                    "BSV", "BCH", "XVG", "USDT", "XRP", "ARB", "BSC", "USDC",
-                   "TRX", "SOL"]
+                   "TRX", "SOL", "DOGE"]
 
 # List of implemented output formats
 OUTPUT_FORMATS = ["TXT", "JSON"]


### PR DESCRIPTION
DOGE is present in the SDN list as a digital currency asset, but it is missing from `POSSIBLE_ASSETS`. Because `POSSIBLE_ASSETS` is also the `choices=` list for the `assets` argument, the tool rejects it outright and the sanctioned Dogecoin addresses are silently never extracted.

Verified against the SDN list downloaded today from the same URL the workflow uses:

```
$ python3 generate-address-list.py DOGE -sdn SDN_ADVANCED.XML
generate-address-list.py: error: argument assets: invalid choice: 'DOGE'
  (choose from 'XBT', 'ETH', 'XMR', 'LTC', 'ZEC', 'DASH', 'BTG', 'ETC',
   'BSV', 'BCH', 'XVG', 'USDT', 'XRP', 'ARB', 'BSC', 'USDC', 'TRX', 'SOL')
```

Walking `ReferenceValueSets/FeatureTypeValues` for every value beginning with `Digital Currency Address - ` gives **19** assets in the current list, against the 18 in `POSSIBLE_ASSETS`:

```
ARB, BCH, BSC, BSV, BTG, DASH, DOGE, ETC, ETH, LTC, SOL,
TRX, USDC, USDT, XBT, XMR, XRP, XVG, ZEC
```

DOGE is `FeatureTypeID 996` and currently carries two addresses:

```
DHzAVdEoL3PjGeLWNdEJwwMA1CeQ9J9Cpo
DTqpKQ96rqkTvHcohQQd9BksmgRjasHgGo
```

With this change both are extracted, and the existing assets are unaffected — I re-ran XBT (522), ETH (96) and SOL (3) against the same file and the counts are unchanged.

**One line is still needed that I can't include here.** The daily job passes the asset tickers explicitly:

```yaml
python3 generate-address-list.py XBT ETH XMR LTC ZEC DASH BTG ETC BSV BCH XVG USDC USDT XRP TRX ARB BSC SOL -f JSON TXT -path ./data -sdn SDN_ADVANCED.XML
```

so `DOGE` needs appending after `SOL` there for the published lists to include it. My token has no `workflow` scope, so a push touching `.github/workflows/` is rejected — if you'd rather it all arrive in one PR, say so and I'll re-authorise and add it.

Context: I found this while looking at #14. I'm not claiming that issue — it's still the CI-guard task and remains open for whoever wants it — this is just the concrete gap it turned up.
